### PR TITLE
Added a progression of dungeons.

### DIFF
--- a/share.sh
+++ b/share.sh
@@ -3,7 +3,7 @@
 
 git clone https://github.com/mocsarcade/enchiridion --branch gh-pages shares
 
-node build --production
+node build
 
 mkdir -p ./shares/$1
 cp -r ./builds/web/* ./shares/$1

--- a/source/index.js
+++ b/source/index.js
@@ -23,7 +23,12 @@ var Game = require("./scripts/model/Game.js")
 
 var state = new Object({
     game: new Game({
-        // ...
+        dungeons: [
+            {colors: ["#444", "#555"], size: 3},
+            {colors: ["#400", "#500"], size: 4},
+            {colors: ["#040", "#050"], size: 4},
+            {colors: ["#004", "#005"], size: 3},
+        ]
     })
 })
 

--- a/source/scripts/Media.js
+++ b/source/scripts/Media.js
@@ -13,9 +13,15 @@ var Media = {
                 },
             },
             effects: {
-                general: {
-                    0: require("../images/shapes/effects/general/0.png"),
-                },
+                general: [
+                    require("../images/shapes/effects/general/0.png"),
+                ],
+            },
+            terrain: {
+                stairs: [
+                    require("../images/shapes/terrain/tiles/30.png"),
+                    require("../images/shapes/terrain/tiles/31.png"),
+                ],
             },
         },
         textures: {
@@ -32,7 +38,7 @@ var Media = {
     },
     colors: {
         yellow: "#DEB74A",
-        red: "#D34328",
+        red: "#BF6960",
     },
 }
 

--- a/source/scripts/Media.js
+++ b/source/scripts/Media.js
@@ -7,6 +7,10 @@ var Media = {
                 2: require("../images/shapes/monsters/2.png"),
                 3: require("../images/shapes/monsters/3.png"),
                 127: require("../images/shapes/monsters/127.png"),
+                bats: {
+                    0: require("../images/shapes/monsters/82.png"),
+                    1: require("../images/shapes/monsters/101.png"),
+                },
             },
             effects: {
                 general: {

--- a/source/scripts/Utility.js
+++ b/source/scripts/Utility.js
@@ -6,3 +6,20 @@ module.exports.queryURL = function(name) {
     var results = new RegExp("[\\?&]" + name + "=([^&#]*)").exec(location.search)
     return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "))
 }
+
+
+module.exports.Point = class Point {
+    constructor(point = {}) {
+        this.x = point.x || 0
+        this.y = point.y || 0
+    }
+    toString() {
+        return this.x + "x" + this.y
+    }
+    toPoint(that = {}) {
+        return new Point({
+            x: this.x + (that.x || 0),
+            y: this.y + (that.y || 0)
+        })
+    }
+}

--- a/source/scripts/model/Adventurer.js
+++ b/source/scripts/model/Adventurer.js
@@ -12,6 +12,8 @@ class Adventurer extends Creature {
         this.color = Media.colors.yellow
         this.transition = true
         this.stack = 2
+        
+        this.type = "Adventurer"
     }
     onLoop() {
         if(Keyb.isJustDown("W")
@@ -30,6 +32,9 @@ class Adventurer extends Creature {
         || Keyb.isJustDown("<right>")) {
             this.move({x: +1})
         }
+        if(Keyb.isJustDown("<space>")) {
+            this.move()
+        }
     }
     onCollide(entity) {
         if(entity.type == "Monster") {
@@ -46,7 +51,7 @@ class Adventurer extends Creature {
             game: this.game
         })
         this.game.adventurer = adventurer
-        this.game.camera.center(adventurer)
+        this.game.camera.center(adventurer.position)
     }
     onHasMoved() {
         this.game.camera.center(this.position)

--- a/source/scripts/model/Adventurer.js
+++ b/source/scripts/model/Adventurer.js
@@ -14,6 +14,7 @@ class Adventurer extends Creature {
         this.stack = 2
         
         this.type = "Adventurer"
+        this.stage = 0
     }
     onLoop() {
         if(Keyb.isJustDown("W")
@@ -46,16 +47,16 @@ class Adventurer extends Creature {
         }
     }
     onDeath() {
-        var adventurer = new Adventurer({
-            position: {x: 0, y: 0},
-            game: this.game
-        })
-        this.game.adventurer = adventurer
-        this.game.camera.center(adventurer.position)
+        this.game.restart()
     }
     onHasMoved() {
+        if(this.position.x == this.game.dungeon.stairs.position.x
+        && this.position.y == this.game.dungeon.stairs.position.y) {
+            this.game.advance()
+        }
+        
         this.game.camera.center(this.position)
-        this.game.monsters.forEach((monster) => {
+        this.game.dungeon.monsters.forEach((monster) => {
             if(!!monster.takeAction) {
                 monster.takeAction()
             }

--- a/source/scripts/model/Camera.js
+++ b/source/scripts/model/Camera.js
@@ -4,6 +4,8 @@ class Camera {
         this.height = protocamera.height || 9
         this.position = protocamera.position || {x: 0, y: 0}
         this.zoom = protocamera.zoom || 1
+        
+        this.key = 0
     }
     // Fixes the camera to
     // center on a position.

--- a/source/scripts/model/Creature.js
+++ b/source/scripts/model/Creature.js
@@ -36,7 +36,7 @@ class Creature extends Entity {
         // Handle collision between this monster
         // and the other monsters in the dungeon.
         
-        var monster = this.game.monsters.find((monster) => {
+        var monster = this.game.dungeon.monsters.find((monster) => {
             if(monster != this) {
                 if(monster.position.x == this.position.x + movement.x
                 && monster.position.y == this.position.y + movement.y) {

--- a/source/scripts/model/Dungeon.js
+++ b/source/scripts/model/Dungeon.js
@@ -36,6 +36,11 @@ class Dungeon {
             width: 3, height: 3
         }))
     }
+    canMove(position) {
+        return this.spaces.some((space) => {
+            return space.contains(position)
+        })
+    }
 }
 
 module.exports = Dungeon

--- a/source/scripts/model/Dungeon.js
+++ b/source/scripts/model/Dungeon.js
@@ -1,66 +1,101 @@
+var Media = require("../Media.js")
 var Space = require("./Space.js")
+var Bat = require("./Monster.js").Bat
+var VampireBat = require("./Monster.js").VampireBat
+var VampireBatKing = require("./Monster.js").VampireBatKing
 
-export class PlaygroundDungeon {
-    constructor(dungeon) {
-        this.spaces = [
-            new Space({
-                position: {x: 0, y: 0},
-                width: 7, height: 7
-            }),
-            new Space({
-                position: {x: 7, y: 2},
-                width: 5, height: 5
-            }),
-            new Space({
-                position: {x: 12, y: 0},
-                width: 3, height: 5
-            }),
-            new Space({
-                position: {x: 10, y: -7},
-                width: 7, height: 7
-            }),
-            new Space({
-                position: {x: 7, y: -7},
-                width: 3, height: 3
-            }),
-            new Space({
-                position: {x: 2, y: -6},
-                width: 5, height: 5
-            }),
-            new Space({
-                position: {x: -3, y: -3},
-                width: 5, height: 3
-            }),
-            new Space({
-                position: {x: 5, y: 7},
-                width: 3, height: 3
-            }),
-        ]
-    }
-}
-
-export class StupidRandomDungeon {
+export class Dungeon {
     constructor(dungeon = new Object()) {
+        this.game = dungeon.game || undefined
+        
+        this.size = dungeon.size || 5
+        
         this.spaces = new Array()
-        
-        this.spaces.push(new Space({
-            position: {x: -3, y: -3},
-            width: 7, height: 7
-        }))
-        
-        for(var i = 0; i < (dungeon.size || 7); i++) {
-            this.spaces.push(new Space({
-                position: {
-                    x: Math.floor(Math.random() * 14) - 7,
-                    y: Math.floor(Math.random() * 14) - 7,
-                },
-                width: 7, height: 7,
-            }))
-        }
+        this.monsters = new Array()
     }
     canMove(position) {
         return this.spaces.some((space) => {
             return space.contains(position)
         })
+    }
+}
+
+export class StaticDungeon extends Dungeon {
+    constructor(dungeon) {
+        super(dungeon)
+        
+        this.spaces = [
+            new Space({
+                position: {x: -3, y: -3},
+                width: 7, height: 7,
+                color: "#444",
+            }),
+            new Space({
+                position: {x: -9, y: -6},
+                width: 6, height: 6,
+                color: "#555",
+            }),
+            new Space({
+                position: {x: -3, y: -12},
+                width: 9, height: 9,
+                color: "#333",
+            }),
+            new Space({
+                position: {x: 4, y: -3},
+                width: 5, height: 5,
+                color: "#666",
+            }),
+            new Space({
+                position: {x: 6, y: -9},
+                width: 6, height: 6,
+                color: "#555",
+            }),
+            new Space({
+                position: {x: -7, y: -10},
+                width: 4, height: 4,
+                color: "#444",
+            }),
+        ]
+        this.monsters = [
+            new Bat({
+                game: this.game,
+                position: {x: -3, y: -3},
+            }),
+            new VampireBat({
+                game: this.game,
+                position: {x: +3, y: -3},
+            }),
+            new VampireBatKing({
+                game: this.game,
+                position: {x: 0, y: -6},
+            }),
+        ]
+    }
+}
+
+export class StupidRandomDungeon extends Dungeon {
+    constructor(dungeon = new Object()) {
+        super(dungeon)
+        
+        for(var i = 0; i < this.size; i++) {
+            this.spaces.push(new Space({
+                color: dungeon.colors[i % 2],
+                position: {x: -3, y: (i * -7) - 3},
+                width: 7, height: 7,
+            }))
+            if(i != 0 && i != this.size - 1) {
+                this.monsters.push(new Bat({
+                    position: {x: 0, y: i * -7},
+                    game: this.game,
+                }))
+            }
+        }
+        
+        this.stairs = {
+            id: "stairs",
+            color: "#222",
+            position: {x: 0, y: (this.size - 1) * -7},
+            shape: Media.images.shapes.terrain.stairs[0],
+        }
     }
 }

--- a/source/scripts/model/Entity.js
+++ b/source/scripts/model/Entity.js
@@ -8,6 +8,8 @@ class Entity {
         this.position = entity.position || {x: 0, y: 0}
         this.width = entity.width || 1
         this.height = entity.height || 1
+        
+        this.key = 0
     }
 }
 

--- a/source/scripts/model/Entity.js
+++ b/source/scripts/model/Entity.js
@@ -5,15 +5,9 @@ class Entity {
         this.id = entity.id || ID.generate()
         this.game = entity.game || undefined
         
-        entity.position = entity.position || {}
-        this.position = {}
-        this.position.x = entity.position.x || 0
-        this.position.y = entity.position.y || 0
+        this.position = entity.position || {x: 0, y: 0}
         this.width = entity.width || 1
         this.height = entity.height || 1
-    }
-    get type() {
-        return this.constructor.name
     }
 }
 

--- a/source/scripts/model/Game.js
+++ b/source/scripts/model/Game.js
@@ -1,78 +1,20 @@
 var Camera = require("./Camera.js")
-var Monster = require("./Monster.js")
 var Adventurer = require("./Adventurer.js")
 
 var PlaygroundDungeon = require("./Dungeon.js").PlaygroundDungeon
 var StupidRandomDungeon = require("./Dungeon.js").StupidRandomDungeon
 
 class Game {
-    constructor() {
-        this.adventurer = new Adventurer({
-            position: {x: 0, y: 0},
-            game: this
-        })
-        this.dungeon = new StupidRandomDungeon({
-            game: this
-        })
+    constructor(game) {
+        this.dungeons = game.dungeons
+        
         this.camera = new Camera({
             position: {x: 0, y: 0},
             width: 16, height: 9,
             zoom: 0.75
         })
-        this.monsters = [
-            new Monster({
-                game: this,
-                position: {x: 5, y: 5},
-                color: "#00C",
-                action: function() {
-                    if(this.getReady()) {
-                        var movement = this.getRandomMovement([
-                            {y: -1}, {y: +1}, {x: -1}, {x: +1}
-                        ])
-                        
-                        // move.
-                        this.move(movement)
-                    }
-                },
-            }),
-            new Monster({
-                game: this,
-                position: {x: 3, y: 3},
-                color: "#0C0",
-                action: function() {
-                    if(this.getReady()) {
-                        var movement = this.getRandomMovement([
-                            {x: -1, y: -1},
-                            {x: +1, y: +1},
-                            {x: -1, y: -1},
-                            {x: +1, y: +1},
-                        ])
-                        
-                        // move.
-                        this.move(movement)
-                    }
-                },
-            }),
-            new Monster({
-                game: this,
-                position: {x: 8, y: 3},
-                color: "#C33",
-                action: function() {
-                    var movement = this.getRandomMovement([
-                        {y: -1},
-                        {y: +1},
-                        {x: -1},
-                        {x: +1}
-                    ])
-                    
-                    // move.
-                    this.move(movement)
-                },
-            }),
-        ]
-        this.effects = new Array()
         
-        this.camera.center(this.adventurer.position)
+        this.restart()
     }
     get entities() {
         // Returns a big list of every
@@ -82,7 +24,8 @@ class Game {
             new Array()
                 .concat(this.adventurer)
                 .concat(this.dungeon.spaces)
-                .concat(this.monsters)
+                .concat(this.dungeon.monsters)
+                .concat(this.dungeon.stairs)
                 .concat(this.effects)
         )
     }
@@ -91,6 +34,39 @@ class Game {
         this.effects.forEach((effect) => {
             effect.onLoop(delta)
         })
+    }
+    restart() {
+        this.adventurer = new Adventurer({
+            position: {x: 0, y: 0},
+            health: 1,
+            game: this
+        })
+        this.start()
+    }
+    start() {
+        if(this.adventurer.stage < this.dungeons.length) {
+            this.adventurer.position.x = 0
+            this.adventurer.position.y = 0
+            var dungeon = this.dungeons[this.adventurer.stage]
+            this.dungeon = new StupidRandomDungeon({
+                colors: dungeon.colors,
+                size: dungeon.size,
+                game: this
+            })
+            
+            this.effects = new Array()
+            
+            this.camera.center(this.adventurer.position)
+            this.camera.key += 1
+        } else {
+            alert("Congratulations! You've won!!")
+        }
+    }
+    advance() {
+        this.adventurer.stage += 1
+        this.adventurer.key += 1
+        
+        this.start()
     }
 }
 

--- a/source/scripts/model/Game.js
+++ b/source/scripts/model/Game.js
@@ -19,12 +19,53 @@ class Game {
         })
         this.monsters = [
             new Monster({
+                game: this,
                 position: {x: 5, y: 5},
-                game: this
+                color: "#00C",
+                action: function() {
+                    if(this.getReady()) {
+                        var movement = this.getRandomMovement([
+                            {y: -1}, {y: +1}, {x: -1}, {x: +1}
+                        ])
+                        
+                        // move.
+                        this.move(movement)
+                    }
+                },
             }),
             new Monster({
+                game: this,
+                position: {x: 3, y: 3},
+                color: "#0C0",
+                action: function() {
+                    if(this.getReady()) {
+                        var movement = this.getRandomMovement([
+                            {x: -1, y: -1},
+                            {x: +1, y: +1},
+                            {x: -1, y: -1},
+                            {x: +1, y: +1},
+                        ])
+                        
+                        // move.
+                        this.move(movement)
+                    }
+                },
+            }),
+            new Monster({
+                game: this,
                 position: {x: 8, y: 3},
-                game: this
+                color: "#C33",
+                action: function() {
+                    var movement = this.getRandomMovement([
+                        {y: -1},
+                        {y: +1},
+                        {x: -1},
+                        {x: +1}
+                    ])
+                    
+                    // move.
+                    this.move(movement)
+                },
             }),
         ]
         this.effects = new Array()

--- a/source/scripts/model/Monster.js
+++ b/source/scripts/model/Monster.js
@@ -6,13 +6,23 @@ class Monster extends Creature {
     constructor(monster) {
         super(monster)
         
-        this.shape = Media.images.shapes.monsters[127]
-        this.color = Media.colors.red
+        this.type = "Monster"
+        
+        this.shapes = Media.images.shapes.monsters.bats
+        this.color = monster.color || "hotpink"
         this.transition = true
         this.stack = 1
+        
+        this.isWaiting = true
+        
+        this.takeAction = monster.action
     }
-    takeAction() {
-        this.move({x: -1}) // dumb behavior
+    get shape() {
+        if(!!this.isWaiting) {
+            return this.shapes[1]
+        } else {
+            return this.shapes[0]
+        }
     }
     onCollide(entity) {
         if(entity.type == "Adventurer") {
@@ -26,6 +36,31 @@ class Monster extends Creature {
     onDeath() {
         var index = this.game.monsters.indexOf(this)
         this.game.monsters.splice(index, 1)
+    }
+    
+    // Given an array of movements, filters for the
+    // movements that won't result in a collision, then
+    // returns a random movement.
+    getRandomMovement(movements = new Array()) {
+        movements = movements.filter((movement) => {
+            return this.game.dungeon.canMove({
+                x: this.position.x + (movement.x || 0),
+                y: this.position.y + (movement.y || 0)
+            })
+        })
+        
+        if(movements.length > 0) {
+            return movements[Math.floor(Math.random() * movements.length)]
+        } else {
+            return {x: 0, y: 0}
+        }
+    }
+    
+    // Toggles between ready and not
+    // ready. Returns true when ready.
+    getReady() {
+        this.isReady = !this.isReady
+        return this.isReady
     }
 }
 

--- a/source/scripts/model/Monster.js
+++ b/source/scripts/model/Monster.js
@@ -2,42 +2,27 @@ var Media = require("../Media.js")
 var Effect = require("./Effect.js")
 var Creature = require("./Creature.js")
 
-class Monster extends Creature {
+export class Monster extends Creature {
     constructor(monster) {
         super(monster)
-        
         this.type = "Monster"
         
-        this.shapes = Media.images.shapes.monsters.bats
-        this.color = monster.color || "hotpink"
         this.transition = true
         this.stack = 1
-        
-        this.isWaiting = true
-        
-        this.takeAction = monster.action
-    }
-    get shape() {
-        if(!!this.isWaiting) {
-            return this.shapes[1]
-        } else {
-            return this.shapes[0]
-        }
     }
     onCollide(entity) {
         if(entity.type == "Adventurer") {
-            this.game.adventurer.takeDamage(this.strength)
             this.game.effects.push(new Effect({
                 position: this.game.adventurer.position,
                 game: this.game,
             }))
+            this.game.adventurer.takeDamage(this.strength)
         }
     }
     onDeath() {
-        var index = this.game.monsters.indexOf(this)
-        this.game.monsters.splice(index, 1)
+        var index = this.game.dungeon.monsters.indexOf(this)
+        this.game.dungeon.monsters.splice(index, 1)
     }
-    
     // Given an array of movements, filters for the
     // movements that won't result in a collision, then
     // returns a random movement.
@@ -55,7 +40,6 @@ class Monster extends Creature {
             return {x: 0, y: 0}
         }
     }
-    
     // Toggles between ready and not
     // ready. Returns true when ready.
     getReady() {
@@ -64,4 +48,51 @@ class Monster extends Creature {
     }
 }
 
-module.exports = Monster
+export class Bat extends Monster {
+    get color() {
+        return "#33C"
+    }
+    get shape() {
+        if(!!this.isReady) {
+            return Media.images.shapes.monsters.bats[1]
+        } else {
+            return Media.images.shapes.monsters.bats[0]
+        }
+    }
+    takeAction() {
+        if(this.getReady()) {
+            this.move(this.getRandomMovement([
+                {y: -1}, {y: +1}, {x: -1}, {x: +1}
+            ]))
+        }
+    }
+}
+
+export class VampireBat extends Monster {
+    get color() {
+        return "#C33"
+    }
+    get shape() {
+        return Media.images.shapes.monsters.bats[0]
+    }
+    takeAction() {
+        this.move(this.getRandomMovement([
+            {y: -1}, {y: +1}, {x: -1}, {x: +1}
+        ]))
+    }
+}
+
+export class VampireBatKing extends Monster {
+    get color() {
+        return "#3C3"
+    }
+    get shape() {
+        return Media.images.shapes.monsters.bats[0]
+    }
+    takeAction() {
+        this.move(this.getRandomMovement([
+            {x: +1, y: -1}, {x: +1, y: +1},
+            {x: -1, y: +1}, {x: +1, y: +1},
+        ]))
+    }
+}

--- a/source/scripts/render/Camera.js
+++ b/source/scripts/render/Camera.js
@@ -5,7 +5,7 @@ var UNIT = 20
 class Camera extends React.Component {
     render() {
         return (
-            <div className="camera" style={this.renderStyle()}>
+            <div className="camera" key={this.props.data.key} style={this.renderStyle()}>
                 {this.props.children}
             </div>
         )

--- a/source/scripts/render/Entity.js
+++ b/source/scripts/render/Entity.js
@@ -7,9 +7,10 @@ var NULL_TEXTURE = Media.images.textures.null
 class Entity extends React.Component {
     render() {
         return React.createElement("div", {
-            // Idthis.props.data
+            // Identity
+            className: "entity",
             id: this.props.data.id,
-            key: this.props.data.id,
+            key: this.props.data.key,
             style: {
                 // Size
                 width: Math.ceil(this.props.data.width || 1) * UNIT + "px",

--- a/source/scripts/render/Entity.js
+++ b/source/scripts/render/Entity.js
@@ -26,7 +26,7 @@ class Entity extends React.Component {
                 backgroundPosition: !!this.props.data.texture ? "bottom" : null,
                 backgroundColor: !!this.props.data.color ? this.props.data.color : null,
                 backgroundImage: !this.props.data.color ? "url(" + NULL_TEXTURE + ")" : null,
-                WebkitMask: !!this.props.data.shape ? "url(" + this.props.data.shape + ")" : null,
+                WebkitMaskImage: !!this.props.data.shape ? "url(" + this.props.data.shape + ")" : null,
                 WebkitMaskRepeat: !!this.props.data.shape ? "no-repeat" : null,
                 WebkitMaskPosition: !!this.props.data.shape ? "bottom" : null,
                 WebkitMaskSize: !!this.props.data.shape ? "contain" : null,


### PR DESCRIPTION
### Dependency

Warning! This pull request has a dependency on #4; don't merge this until that is merged!
### Changes
- `Dungeon` now accepts parameters for that level of the dungeon, which at the moment only includes the `size` and `colors`. Each of these live in `Game`, which has an array of each level or stage of the dungeon, which the `Adventurer` progresses through.
- `Dungeon` can now have stairs. At the moment, their declaration is a little informal, but we'll eventually refactor them into their own class. If the `Adventurer` collides with the stairs, they move on to the next level.
- `Dungeon` now holds the `monsters`, just because there will never be a time when we want to reset the dungeon and not the monsters, and also because it'll make generating the placement of the monsters much easier.
- `Game` is now responsible for advancing between the levels when the `Adventurer` reaches the stairs, and reseting the levels when the `Adventurer` dies.
- `StupidRandomDungeon` is barely even random anymore, but it's still stupid. Just a straight line between the `Adventurer` and the stairs.
- You can win! Uh.. kinda. A pop-up appears to congratulate you on your victory. :p
- `Monster` now has subclasses for `Bat` (blue), `VampireBat` (red), and `VampireBatKing` (green). I really wanted to just pass in different variables to `Monster`, but there just wasn't enough control.
### Link

https://mocsarcade.github.io/enchiridion/pr6
### Screenshot

![pr6](https://cloud.githubusercontent.com/assets/1202938/13561254/a2e981ec-e3df-11e5-9257-9a3702b32204.gif)
