### PR TITLE
Personal share

### DIFF
--- a/share.sh
+++ b/share.sh
@@ -1,12 +1,15 @@
 # To run:
 # ./share.sh v.0.0.1
 
-git clone https://github.com/mocsarcade/enchiridion --branch gh-pages shares
+git clone $(git remote -v | grep push | cut -f2 | cut -d ' ' -f1) --branch gh-pages shares
 
 node build --production
 
 mkdir -p ./shares/$1
 cp -r ./builds/web/* ./shares/$1
+
+git --git-dir=./shares/.git --work-tree=./shares config user.email "$(git config user.email)"
+git --git-dir=./shares/.git --work-tree=./shares config user.name "$(git config user.name)"
 
 git --git-dir=./shares/.git --work-tree=./shares add $1
 git --git-dir=./shares/.git --work-tree=./shares commit -m "Pushed $1"
@@ -14,7 +17,9 @@ git --git-dir=./shares/.git --work-tree=./shares push origin gh-pages
 
 rm -rf shares
 
+REPO="$(git remote -v | grep push | cut -f2 | cut -d ' ' -f1 | cut -d ':' -f2)"
+
 echo
 echo Share your build by going to:
-echo https://mocsarcade.github.io/enchiridion/$1
+echo https://$(echo $REPO | cut -d '/' -f1).github.io/$(echo $REPO | cut -d '/' -f2 | cut -d '.' -f1)/$1
 echo

--- a/source/index.js
+++ b/source/index.js
@@ -29,9 +29,6 @@ import Render from "./scripts/utility/Render.js"
 
 var render = new Render()
 var loop = new Afloop((delta) => {
-    if(state.game.isReady) {
-        state.game.update(delta)
-    }
-
+    state.game.update(delta)
     render(state)
 })


### PR DESCRIPTION
The share script was set up to always push to `gh-pages` on `mocsarcade/enchiridion`. I've made it pick up your push remote and push to the `gh-pages` branch on that repo. For example, I set `origin` to fetch from `mocsarcade/enchiridion` and push to `willamin/enchiridion`, so now the share script will push to the `gh-pages` branch of `willamin/enchiridion`. That way changes I want to publicly share won't clog up the `mocsarcade/enchiridion` repo. 

I use git for work in addition to personal/school projects so I end up needing to set my user.email separately per project instead of globally. I change the share script to pull that info from the actual repo to be used in the ephemeral `shares` repo.

Somehow I got another commit stuffed in with this one that I didn't mean to. I tried rebasing, but it didn't go away. ¯_(ツ)_/¯
